### PR TITLE
[Android] Add setting to allow Media Controls show in Compact Notification

### DIFF
--- a/android/src/main/kotlin/com/danielgauci/native_audio/AudioService.kt
+++ b/android/src/main/kotlin/com/danielgauci/native_audio/AudioService.kt
@@ -311,6 +311,7 @@ class AudioService : Service() {
 
         val mediaStyle = androidx.media.app.NotificationCompat.MediaStyle()
                 .setMediaSession(session.sessionToken)
+                .setShowActionsInCompactView(0, 1, 2)
                 .setCancelButtonIntent(stopIntent)
                 .setShowCancelButton(true)
 


### PR DESCRIPTION
For android notification the media controls would only show for the expanded notification. Adding this one setting allows them to show also in compact. 

can add more button for expanded mode and have a few in compact mode.