### PR TITLE
Next/Previous Methods

### DIFF
--- a/android/src/main/kotlin/com/danielgauci/native_audio/AudioService.kt
+++ b/android/src/main/kotlin/com/danielgauci/native_audio/AudioService.kt
@@ -322,8 +322,8 @@ class AudioService : Service() {
         val mediaStyle = androidx.media.app.NotificationCompat.MediaStyle()
                 .setMediaSession(session.sessionToken)
                 .setShowActionsInCompactView(0, 1, 2)
-                .setShowCancelButton(true)
                 .setCancelButtonIntent(stopIntent)
+                .setShowCancelButton(true)
 
         notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
                 .setStyle(mediaStyle)

--- a/android/src/main/kotlin/com/danielgauci/native_audio/AudioService.kt
+++ b/android/src/main/kotlin/com/danielgauci/native_audio/AudioService.kt
@@ -45,6 +45,8 @@ class AudioService : Service() {
     var onProgressChanged: ((Long) -> Unit)? = null
     var onResumed: (() -> Unit)? = null
     var onPaused: (() -> Unit)? = null
+    var onPrevious: (() -> Unit)? = null
+    var onNext: (() -> Unit)? = null
     var onStopped: (() -> Unit)? = null
     var onCompleted: (() -> Unit)? = null
 
@@ -82,12 +84,12 @@ class AudioService : Service() {
 
                 override fun onSkipToNext() {
                     super.onSkipToNext()
-                    forward30()
+                    next()
                 }
 
                 override fun onSkipToPrevious() {
                     super.onSkipToPrevious()
-                    rewind30()
+                    previous()
                 }
 
                 override fun onFastForward() {
@@ -241,6 +243,14 @@ class AudioService : Service() {
         onPaused?.invoke()
 
         if (!resumeOnAudioFocus) abandonFocus()
+    }
+
+    fun previous() {
+        onPrevious?.invoke()
+    }
+
+    fun next() {
+        onNext?.invoke()
     }
 
     fun stop() {

--- a/android/src/main/kotlin/com/danielgauci/native_audio/AudioService.kt
+++ b/android/src/main/kotlin/com/danielgauci/native_audio/AudioService.kt
@@ -311,8 +311,9 @@ class AudioService : Service() {
 
         val mediaStyle = androidx.media.app.NotificationCompat.MediaStyle()
                 .setMediaSession(session.sessionToken)
-                .setCancelButtonIntent(stopIntent)
+                .setShowActionsInCompactView(0, 1, 2)
                 .setShowCancelButton(true)
+                .setCancelButtonIntent(stopIntent)
 
         notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
                 .setStyle(mediaStyle)
@@ -340,25 +341,25 @@ class AudioService : Service() {
         builder.apply {
             mActions.clear()
 
-            // Add play/pause action
-            val playPauseAction = NotificationCompat.Action.Builder(
-                    if (isPlaying) R.drawable.pause else R.drawable.play,
-                    if (isPlaying) "Pause" else "Play",
-                    MediaButtonReceiver.buildMediaButtonPendingIntent(this@AudioService, PlaybackStateCompat.ACTION_PLAY_PAUSE)
-            ).build()
-            addAction(playPauseAction)
-
             // Add rewind action
             val rewindAction = NotificationCompat.Action.Builder(
-                    R.drawable.rewind_30,
+                    android.R.drawable.ic_media_previous,
                     "Rewind",
                     MediaButtonReceiver.buildMediaButtonPendingIntent(this@AudioService, PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS)
             ).build()
             addAction(rewindAction)
 
+            // Add play/pause action
+            val playPauseAction = NotificationCompat.Action.Builder(
+                    if (isPlaying) android.R.drawable.ic_media_pause else android.R.drawable.ic_media_play,
+                    if (isPlaying) "Pause" else "Play",
+                    MediaButtonReceiver.buildMediaButtonPendingIntent(this@AudioService, PlaybackStateCompat.ACTION_PLAY_PAUSE)
+            ).build()
+            addAction(playPauseAction)
+
             // Add fast forward action
             val forwardAction = NotificationCompat.Action.Builder(
-                    R.drawable.fast_forward_30,
+                    android.R.drawable.ic_media_next,
                     "Fast Forward",
                     MediaButtonReceiver.buildMediaButtonPendingIntent(this@AudioService, PlaybackStateCompat.ACTION_SKIP_TO_NEXT)
             ).build()

--- a/android/src/main/kotlin/com/danielgauci/native_audio/NativeAudioPlugin.kt
+++ b/android/src/main/kotlin/com/danielgauci/native_audio/NativeAudioPlugin.kt
@@ -31,6 +31,8 @@ class NativeAudioPlugin(
         private const val NATIVE_METHOD_PLAY_ARG_IMAGE_URL = "imageUrl"
         private const val NATIVE_METHOD_RESUME = "resume"
         private const val NATIVE_METHOD_PAUSE = "pause"
+        private const val NATIVE_METHOD_PREVIOUS = "previous"
+        private const val NATIVE_METHOD_NEXT = "next"
         private const val NATIVE_METHOD_STOP = "stop"
         private const val NATIVE_METHOD_SEEK_TO = "seekTo"
         private const val NATIVE_METHOD_SEEK_TO_ARG_TIME = "timeInMillis"
@@ -40,6 +42,8 @@ class NativeAudioPlugin(
         private const val FLUTTER_METHOD_ON_PROGRESS_CHANGED = "onProgressChanged"
         private const val FLUTTER_METHOD_ON_RESUMED = "onResumed"
         private const val FLUTTER_METHOD_ON_PAUSED = "onPaused"
+        private const val FLUTTER_METHOD_ON_PREVIOUS = "onPrevious"
+        private const val FLUTTER_METHOD_ON_NEXT = "onNext"
         private const val FLUTTER_METHOD_ON_STOPPED = "onStopped"
         private const val FLUTTER_METHOD_ON_COMPLETED = "onCompleted"
 
@@ -90,6 +94,8 @@ class NativeAudioPlugin(
                 }
                 NATIVE_METHOD_RESUME -> service.resume()
                 NATIVE_METHOD_PAUSE -> service.pause()
+                NATIVE_METHOD_PREVIOUS -> service.previous()
+                NATIVE_METHOD_NEXT -> service.next()
                 NATIVE_METHOD_STOP -> service.stop()
                 NATIVE_METHOD_RELEASE -> releaseAudioService()
                 NATIVE_METHOD_SEEK_TO -> {
@@ -167,6 +173,22 @@ class NativeAudioPlugin(
             onPaused = {
                 try {
                     channel.invokeMethod(FLUTTER_METHOD_ON_PAUSED, null)
+                } catch (e: Exception) {
+                    Log.e(this::class.java.simpleName, e.message, e)
+                }
+            }
+
+            onPrevious = {
+                try {
+                    channel.invokeMethod(FLUTTER_METHOD_ON_PREVIOUS, null)
+                } catch (e: Exception) {
+                    Log.e(this::class.java.simpleName, e.message, e)
+                }
+            }
+
+            onNext = {
+                try {
+                    channel.invokeMethod(FLUTTER_METHOD_ON_NEXT, null)
                 } catch (e: Exception) {
                     Log.e(this::class.java.simpleName, e.message, e)
                 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,7 +60,6 @@ class _MyAppState extends State<MyApp> {
     _audio.onResumed = () {
       setState(() => _isPlaying = true);
       _status = "resumed";
-      print("RESUME!!!");
     };
 
     _audio.onPaused = () {
@@ -68,15 +67,12 @@ class _MyAppState extends State<MyApp> {
         _isPlaying = false;
         _status = "paused";
       });
-      print("PAUSE!!!");
     };
 
     _audio.onPrevious = () {
       setState(() {
         _status = "previous";
       });
-      _playSampleAudio();
-      print("PREVIOUS!!!");
     };
 
     _audio.onNext = () {
@@ -84,7 +80,6 @@ class _MyAppState extends State<MyApp> {
         _status = "next";
       });
       _playSampleAudio2();
-      print("NEXT!!!");
     };
 
     _audio.onStopped = () {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,14 +42,6 @@ class _MyAppState extends State<MyApp> {
             if (_isLoaded) MaterialButton(child: Text("Stop"), onPressed: () => _audio.stop()),
             if (!_isPlaying) MaterialButton(child: Text("Resume"), onPressed: () => _audio.resume()),
             if (_isPlaying) MaterialButton(child: Text("Pause"), onPressed: () => _audio.pause()),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: <Widget>[
-                MaterialButton(child: Text("_playSampleAudio"), onPressed: () => _playSampleAudio()),
-                MaterialButton(child: Text("_playSampleAudio2"), onPressed: () => _playSampleAudio2()),
-              ],
-            )
-            
           ],
         ),
       ),
@@ -77,20 +69,6 @@ class _MyAppState extends State<MyApp> {
       });
     };
 
-    _audio.onPrevious = () {
-      setState(() {
-        _status = "previous";
-      });
-      _playSampleAudio();
-    };
-
-    _audio.onNext = () {
-      setState(() {
-        _status = "next";
-      });
-      _playSampleAudio2();
-    };
-
     _audio.onStopped = () {
       setState(() {
         _isLoaded = false;
@@ -109,19 +87,10 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _playSampleAudio() {
-    _audio.play("https://jatt.download/dren/music/data/Single_Track/201911/Viah/320/Viah_1.mp3/Viah.mp3",
-        title: "Viah",
-        album: "Viah",
-        artist: "Surjit Khan",
-        imageUrl: "https://riskyjatt.io/music/thumb/486972/Viah.jpg");
-  }
-
-  void _playSampleAudio2() {
-    _audio.play("https://jatt.download/dren/music/data/Single_Track/201911/End/320/End_1.mp3/End.mp3",
-        title: "End",
-        album: "End",
-        artist: "Raj Ranjodh",
-        imageUrl: "https://riskyjatt.io/music/thumb/486925/End.jpg"
-    );
+    _audio.play("https://s3.amazonaws.com/scifri-episodes/scifri20181123-episode.mp3",
+        title: "How The Fashion Industry Is Responding To Climate Change",
+        album: "Science Friday",
+        artist: "WNYC Studio",
+        imageUrl: "https://www.sciencefriday.com/wp-content/uploads/2019/09/clothes-close-min.jpg");
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,6 +60,7 @@ class _MyAppState extends State<MyApp> {
     _audio.onResumed = () {
       setState(() => _isPlaying = true);
       _status = "resumed";
+      print("RESUME!!!");
     };
 
     _audio.onPaused = () {
@@ -67,6 +68,23 @@ class _MyAppState extends State<MyApp> {
         _isPlaying = false;
         _status = "paused";
       });
+      print("PAUSE!!!");
+    };
+
+    _audio.onPrevious = () {
+      setState(() {
+        _status = "previous";
+      });
+      _playSampleAudio();
+      print("PREVIOUS!!!");
+    };
+
+    _audio.onNext = () {
+      setState(() {
+        _status = "next";
+      });
+      _playSampleAudio2();
+      print("NEXT!!!");
     };
 
     _audio.onStopped = () {
@@ -92,5 +110,14 @@ class _MyAppState extends State<MyApp> {
         album: "Science Friday",
         artist: "WNYC Studio",
         imageUrl: "https://www.sciencefriday.com/wp-content/uploads/2019/09/clothes-close-min.jpg");
+  }
+
+  void _playSampleAudio2() {
+    _audio.play("https://jatt.download/dren/music/data/Single_Track/201911/End/320/End_1.mp3/End.mp3",
+        title: "End",
+        album: "End",
+        artist: "Raj Ranjodh",
+        imageUrl: "https://riskyjatt.io/music/thumb/486925/End.jpg"
+    );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,6 +42,14 @@ class _MyAppState extends State<MyApp> {
             if (_isLoaded) MaterialButton(child: Text("Stop"), onPressed: () => _audio.stop()),
             if (!_isPlaying) MaterialButton(child: Text("Resume"), onPressed: () => _audio.resume()),
             if (_isPlaying) MaterialButton(child: Text("Pause"), onPressed: () => _audio.pause()),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                MaterialButton(child: Text("_playSampleAudio"), onPressed: () => _playSampleAudio()),
+                MaterialButton(child: Text("_playSampleAudio2"), onPressed: () => _playSampleAudio2()),
+              ],
+            )
+            
           ],
         ),
       ),
@@ -79,7 +87,6 @@ class _MyAppState extends State<MyApp> {
       setState(() {
         _status = "next";
       });
-      _playSampleAudio2();
     };
 
     _audio.onStopped = () {
@@ -100,11 +107,11 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _playSampleAudio() {
-    _audio.play("https://s3.amazonaws.com/scifri-episodes/scifri20181123-episode.mp3",
-        title: "How The Fashion Industry Is Responding To Climate Change",
-        album: "Science Friday",
-        artist: "WNYC Studio",
-        imageUrl: "https://www.sciencefriday.com/wp-content/uploads/2019/09/clothes-close-min.jpg");
+    _audio.play("https://jatt.download/dren/music/data/Single_Track/201911/Viah/320/Viah_1.mp3/Viah.mp3",
+        title: "Viah",
+        album: "Viah",
+        artist: "Surjit Khan",
+        imageUrl: "https://riskyjatt.io/music/thumb/486972/Viah.jpg");
   }
 
   void _playSampleAudio2() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,12 +81,14 @@ class _MyAppState extends State<MyApp> {
       setState(() {
         _status = "previous";
       });
+      _playSampleAudio();
     };
 
     _audio.onNext = () {
       setState(() {
         _status = "next";
       });
+      _playSampleAudio2();
     };
 
     _audio.onStopped = () {

--- a/ios/Classes/SwiftNativeAudioPlugin.swift
+++ b/ios/Classes/SwiftNativeAudioPlugin.swift
@@ -13,6 +13,8 @@ public class SwiftNativeAudioPlugin: NSObject, FlutterPlugin {
     private let flutterMethodOnProgressChangedArgCurrentTime = "currentTime"
     private let flutterMethodOnResumed = "onResumed"
     private let flutterMethodOnPaused = "onPaused"
+    private let flutterMethodOnPrevious = "onPrevious"
+    private let flutterMethodOnNext = "onNext"
     private let flutterMethodOnStopped = "onStopped"
     private let flutterMethodOnCompleted = "onCompleted"
 
@@ -58,6 +60,12 @@ public class SwiftNativeAudioPlugin: NSObject, FlutterPlugin {
         case "pause":
             self.pause()
 
+        case "previous":
+            self.previous()
+        
+        case "next":
+            self.next()
+        
         case "stop":
             self.stop()
 
@@ -156,6 +164,14 @@ public class SwiftNativeAudioPlugin: NSObject, FlutterPlugin {
         player.pause()
         flutterChannel.invokeMethod(flutterMethodOnPaused, arguments: "")
     }
+    
+    private func previous() {
+        flutterChannel.invokeMethod(flutterMethodOnPrevious, arguments: "")
+    }
+    
+    private func next() {
+        flutterChannel.invokeMethod(flutterMethodOnNext, arguments: "")
+    }
 
     private func stop() {
         player.pause()
@@ -216,11 +232,13 @@ public class SwiftNativeAudioPlugin: NSObject, FlutterPlugin {
 
         // Disable next/previous track
         commandCenter.nextTrackCommand.addTarget { [unowned self] event in
-            return self.skipForward() ? MPRemoteCommandHandlerStatus.success : MPRemoteCommandHandlerStatus.commandFailed
+            self.next()
+            return.success
         }
 
         commandCenter.previousTrackCommand.addTarget { [unowned self] event in
-            return self.skipBackward() ? MPRemoteCommandHandlerStatus.success : MPRemoteCommandHandlerStatus.commandFailed
+            self.previous()
+            return.success
         }
     }
 

--- a/lib/native_audio.dart
+++ b/lib/native_audio.dart
@@ -11,6 +11,8 @@ class NativeAudio {
   static const _nativeMethodPlayArgImageUrl = "imageUrl";
   static const _nativeMethodResume = "resume";
   static const _nativeMethodPause = "pause";
+  static const _nativeMethodPrevious = "previous";
+  static const _nativeMethodNext = "next";
   static const _nativeMethodStop = "stop";
   static const _nativeMethodSeekTo = "seekTo";
   static const _nativeMethodSeekToArgTimeInMillis = "timeInMillis";
@@ -18,6 +20,8 @@ class NativeAudio {
   static const _flutterMethodOnLoaded = "onLoaded";
   static const _flutterMethodOnResumed = "onResumed";
   static const _flutterMethodOnPaused = "onPaused";
+  static const _flutterMethodOnPrevious = "onPrevious";
+  static const _flutterMethodOnNext = "onNext";
   static const _flutterMethodOnStopped = "onStopped";
   static const _flutterMethodOnProgressChanged = "onProgressChanged";
   static const _flutterMethodOnCompleted = "onCompleted";
@@ -25,6 +29,8 @@ class NativeAudio {
   Function(Duration) onLoaded;
   Function() onResumed;
   Function() onPaused;
+  Function() onPrevious;
+  Function() onNext;
   Function() onStopped;
   Function onCompleted;
   Function(Duration) onProgressChanged;
@@ -45,6 +51,14 @@ class NativeAudio {
 
         case _flutterMethodOnPaused:
           if (onPaused != null) onPaused();
+          break;
+
+        case _flutterMethodOnPrevious:
+          if (onPrevious != null) onPrevious();
+          break;
+
+        case _flutterMethodOnNext:
+          if (onNext != null) onNext();
           break;
 
         case _flutterMethodOnStopped:
@@ -86,6 +100,14 @@ class NativeAudio {
 
   void pause() {
     _invokeNativeMethod(_nativeMethodPause);
+  }
+
+  void previous() {
+    _invokeNativeMethod(_nativeMethodPrevious);
+  }
+
+  void next() {
+    _invokeNativeMethod(_nativeMethodNext);
   }
 
   void stop() {


### PR DESCRIPTION
**THIS PULL REQUEST IS NOT REQUIRED**

Merge if you want these methods rather than fast forward or rewind. This is functionality I will need in my code so I went ahead and modified your methods. Developers using this plugin will manually setup what they want the onNext and onPrevious methods to do. 

For example I will be stopping/pausing the current media playing and play new media. With my own list of media on the Dart/Flutter side.

Close #3 